### PR TITLE
Make kramdown install and loading optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Kramdown loads during runtime if no other parser has been configured.
+
 ## 1.0.2
 
 - Fix threading issue with default parser

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ So why not write your templates once in markdown, and have them translated to te
 
 Gemfile:
 
-```
+```ruby
 gem 'maildown'
 ```
 
@@ -32,7 +32,12 @@ Once you've got a file named `.md.erb` in your mailer directory, I recommend ver
 
 ## Configure Markdown Renderer
 
-By default maildown uses the [kramdown](https://github.com/gettalong/kramdown) markdown parser by default. Kramdown is pure ruby, so it runs the same across all ruby implementations: jruby, rubinius, MRI, etc. You can configure another parser if you like using the `Maildown::MarkdownEngine.set` method and pasing it a block. If you wanted to use Redcarpet you could set it like this:
+Maildown uses [kramdown](https://github.com/gettalong/kramdown) by default.
+Kramdown is pure ruby, so it runs the same across all ruby implementations:
+jruby, rubinius, MRI, etc. You can configure another parser if you like using
+the `Maildown::MarkdownEngine.set` method and pasing it a block.
+
+For example, if you wanted to use Redcarpet you could set it like this:
 
 ```ruby
 Maildown::MarkdownEngine.set do |text|
@@ -41,7 +46,8 @@ Maildown::MarkdownEngine.set do |text|
 end
 ```
 
-When maildown needs an html document the block will be called with the markdown text. The result should be html.
+When maildown needs an html document the block will be called with the markdown
+text. The result should be html.
 
 ## Helpers in Markdown files
 

--- a/lib/maildown.rb
+++ b/lib/maildown.rb
@@ -1,5 +1,3 @@
-require 'kramdown'
-
 module Maildown
 end
 

--- a/lib/maildown/markdown_engine.rb
+++ b/lib/maildown/markdown_engine.rb
@@ -13,6 +13,8 @@ module Maildown
     end
 
     def self.default
+      require 'kramdown' unless defined? Kramdown
+
       ->(string) { Kramdown::Document.new(string).to_html }
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
+require "kramdown"
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -13,7 +14,6 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 # if ActiveSupport::TestCase.method_defined?(:fixture_path=)
 #   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 # end
-
 
 def orig_text_response
   {:body=>"Hi,\n\n##\n\n\nName:\n  test_to_yaml_with_time_with_zone_should_not_raise_exception\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L7\nName:\n  test_roundtrip\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L20\nName:\n  test_roundtrip_serialized_column\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L27\nName:\n  test_encode_with_coder\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L32\nName:\n  test_psych_roundtrip\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L39\nName:\n  test_psych_roundtrip_new_object\nLocation:\n  https://github.com/rails/rails/blob/master/test/cases/yaml_serialization_test.rb/#L46\n\n--\n@schneems\n", :content_type=>"text/plain"}.dup


### PR DESCRIPTION
Kramdown was automatically installed as a dependency and loaded at boot time. This happened even when a different parser was set during configuration. This makes kramdown a development dependency and eliminates the require statement from `markdown.rb`.

I've updated the changelog and the readme with relevant information. Thoughts on it @schneems?
